### PR TITLE
Implement an API to pick different widget styles

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -23,6 +23,8 @@ globals = {
 	"CloseSpecialWindows",
 	"ColorPickerFrame",
 	"SlashCmdList", "hash_SlashCmdList",
+
+	"ACEGUI_STYLE_CLASSIC",
 }
 
 read_globals = {


### PR DESCRIPTION
The public API is extended to take a widget style parameter anywhere a
widget type is being supplied. If its not specified, classic style is
assumed.

The style parameter is a string for future expandability,
currently defined as ACEGUI_STYLE_CLASSIC ("classic") for the default
style shipping with AceGUI-3.0

Additional styles have to be registered, and can optionally take a
parent style, which causes widgets not present in the requested style to
be looked up from the parent instead. This enables partial style
overrides.

API Changes:
AceGUI:RegisterStyle(style, parentStyle)
AceGUI:Create(type, style)
AceGUI:RegisterWidgetType(Name, Constructor, Version, Style)
AceGUI:GetWidgetVersion(type, style)
AceGUI:GetNextWidgetNum(type, style)
AceGUI:GetWidgetCount(type, style)