### PR TITLE
Remove InterfaceOptionsFramePanelContainer

### DIFF
--- a/AceGUI-3.0/widgets/AceGUIContainer-BlizOptionsGroup.lua
+++ b/AceGUI-3.0/widgets/AceGUIContainer-BlizOptionsGroup.lua
@@ -99,7 +99,7 @@ local methods = {
 Constructor
 -------------------------------------------------------------------------------]]
 local function Constructor()
-	local frame = CreateFrame("Frame", nil, InterfaceOptionsFramePanelContainer)
+	local frame = CreateFrame("Frame")
 	frame:Hide()
 
 	-- support functions for the Blizzard Interface Options


### PR DESCRIPTION
Passing InterfaceOptionsFramePanelContainer as parent is no longer needed as of 3.4.2