### PR TITLE
AceDB-3.0: Respect falsy ["*"] defaults

### DIFF
--- a/AceDB-3.0/AceDB-3.0.lua
+++ b/AceDB-3.0/AceDB-3.0.lua
@@ -111,7 +111,12 @@ local function copyDefaults(dest, src)
 				end
 			else
 				-- Values are not tables, so this is just a simple return
-				local mt = {__index = function(t,k2) return k2~=nil and v or nil end}
+				local mt = {
+					__index = function(t,k2)
+							if k2 == nil then return nil end
+							return v
+						end,
+				}
 				setmetatable(dest, mt)
 			end
 		elseif type(v) == "table" then


### PR DESCRIPTION
Setting `["*"] = false` in an options table currently does nothing, since the option will still appear to be nil when accessed.

This change makes it easier to notice incorrect db references, since a return value of `nil` will only happen when a default value has actually not been set.