### PR TITLE
Add support for per-prefix transmission throttling

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -39,6 +39,7 @@ read_globals = {
 	"ClearCursor",
 	"CreateFont",
 	"CreateFrame",
+	"Enum.SendAddonMessageResult",
 	"GetCurrentRegion",
 	"GetCurrentRegionName",
 	"GetCursorInfo",

--- a/AceComm-3.0/AceComm-3.0.lua
+++ b/AceComm-3.0/AceComm-3.0.lua
@@ -20,7 +20,7 @@ TODO: Time out old data rotting around from dead senders? Not a HUGE deal since 
 local CallbackHandler = LibStub("CallbackHandler-1.0")
 local CTL = assert(ChatThrottleLib, "AceComm-3.0 requires ChatThrottleLib")
 
-local MAJOR, MINOR = "AceComm-3.0", 12
+local MAJOR, MINOR = "AceComm-3.0", 13
 local AceComm,oldminor = LibStub:NewLibrary(MAJOR, MINOR)
 
 if not AceComm then return end
@@ -97,8 +97,8 @@ function AceComm:SendCommMessage(prefix, text, distribution, target, prio, callb
 
 	local ctlCallback = nil
 	if callbackFn then
-		ctlCallback = function(sent)
-			return callbackFn(callbackArg, sent, textlen)
+		ctlCallback = function(sent, sendResult)
+			return callbackFn(callbackArg, sent, textlen, sendResult)
 		end
 	end
 

--- a/AceComm-3.0/ChatThrottleLib.lua
+++ b/AceComm-3.0/ChatThrottleLib.lua
@@ -542,7 +542,7 @@ function ChatThrottleLib:SendChatMessage(prio, prefix,   text, chattype, languag
 	msg.callbackFn = callbackFn
 	msg.callbackArg = callbackArg
 
-	self:Enqueue(prio, queueName or (prefix..(chattype or "SAY")..(destination or "")), msg)
+	self:Enqueue(prio, queueName or prefix, msg)
 end
 
 
@@ -601,7 +601,7 @@ function ChatThrottleLib:SendAddonMessage(prio, prefix, text, chattype, target, 
 	msg.callbackFn = callbackFn
 	msg.callbackArg = callbackArg
 
-	self:Enqueue(prio, queueName or (prefix..chattype..(target or "")), msg)
+	self:Enqueue(prio, queueName or prefix, msg)
 end
 
 


### PR DESCRIPTION
In patch 4.4.0 and 10.2.7 Blizzard have tightened the restrictions on addon comms to add a per-prefix throttle across all chat types, effectively restricting them to one message per second with a small accrued burst capacity.

The SendAddonMessage APIs now return an enum result code which includes information if this client-side throttle has been applied to a submitted message. With it, we can now properly handle throttling in CTL and avoid situations where addon messages would be dropped for exceeding it.

This PR takes into consideration the discussion on Discord and takes a slightly different approach to the other open one by instead implementing the concept of a "blocked" pipe.

A pipe enters the "blocked" state whenever a message at its head is attempted to be sent off, and a throttle result code is returned from the API.

When transitioning to this state, the pipe is removed from the transmission ring of its parent priority and is instead placed into a separate (and new) blocked ring. This prevents the despool logic from seeing blocked pipes and pointlessly attempting to re-send on them.

Periodically - currently every 0.35s - the contents of the blocked rings in each priority are reintegrated back into the transmission rings, allowing us to attempt re-transmission of queued messages.

This means there may be some added latency when a prefix entered a blocked state if the API was about to perhaps unblock it, but this also allows us to reallocate bandwidth that would be consumed by priorities that are fully blocked to others that can more readily use it. The value of 0.35s was chosen almost arbitrarily and could be tuned later if found to be a bit high.

It's important to also note that we specifically don't consider the 'ChannelThrottle' return code a retryable error condition. The reasoning here is that this throttle isn't new, and the API appears to enqueue these messages for submission anyway but with a hefty delay by grouping them into batches. There are additional server-side throttles (and a confirmed bug) that mean these sometimes may not make it through to their destination however, and so for consistency with the underlying API we treat it as a failure condition.

Aside from prefix throttling, there's a few other small changes.

- Failure to send a message either due to an error or throttling no longer consumes bandwidth that had been allocated to a priority.

- Priorities that enter a blocked or empty state now release their bandwidth back to the global pool for redistribution immediately, instead of waiting until there's no data queued up whatsoever. This is required to deal with edge cases involving priorities sending many small messages on one prefix infinitely accumulating bandwidth.

- Transmission logic has been centralized into a new PerformSend function to minimize the number of call sites individually needing to remember to toggle boolean variables with each Send call.

- Queued transmissions no longer apply checks to see if the player is in a group or raid. The API has dedicated return codes for this condition and has been tested to not trigger erroneous system message spam if attempting to send a message to either chat type while not being in a group. This is not the case for guilds, however the library never checked this case previously so one hasn't been added.

- User-supplied callbacks are now supplied an accurate 'didSend' parameter that will be false if the API returns a non-throttle-related error code.

- User-supplied callbacks are additionally now supplied the new result code as a third parameter. For Classic Era, we synthesize one from a subset of the enum values based off the boolean result that the API will still be providing there for now.

- User-supplied callbacks no longer let errors blow things up in an uncontrolled manner by being subject to securecall wrapping. This is also consistently applied irrespective of whether or not the send itself was immediate or queued.

- Some compatibility with the pre-8.0 global SendAddonMessage API was removed as it's no longer needed.