### PR TITLE
ChatThrottleLib: Add Battle.net addon message support

### DIFF
--- a/AceComm-3.0/ChatThrottleLib.lua
+++ b/AceComm-3.0/ChatThrottleLib.lua
@@ -251,7 +251,7 @@ function ChatThrottleLib:Init()
 		end)
 	end
 
-	-- v27: Hook BNSendGameData for traffic logging
+	-- v29: Hook BNSendGameData for traffic logging
 	if not self.securelyHookedBNGameData then
 		self.securelyHookedBNGameData = true
 		hooksecurefunc("BNSendGameData", function(...)

--- a/AceComm-3.0/ChatThrottleLib.lua
+++ b/AceComm-3.0/ChatThrottleLib.lua
@@ -23,7 +23,7 @@
 -- LICENSE: ChatThrottleLib is released into the Public Domain
 --
 
-local CTL_VERSION = 28
+local CTL_VERSION = 29
 
 local _G = _G
 
@@ -251,6 +251,14 @@ function ChatThrottleLib:Init()
 		end)
 	end
 
+	-- v27: Hook BNSendGameData for traffic logging
+	if not self.securelyHookedBNGameData then
+		self.securelyHookedBNGameData = true
+		hooksecurefunc("BNSendGameData", function(...)
+			return ChatThrottleLib.Hook_BNSendGameData(...)
+		end)
+	end
+
 	self.nBypass = 0
 end
 
@@ -281,6 +289,9 @@ function ChatThrottleLib.Hook_SendAddonMessage(prefix, text, chattype, destinati
 end
 function ChatThrottleLib.Hook_SendAddonMessageLogged(prefix, text, chattype, destination, ...)
 	ChatThrottleLib.Hook_SendAddonMessage(prefix, text, chattype, destination, ...)
+end
+function ChatThrottleLib.Hook_BNSendGameData(destination, prefix, text)
+	ChatThrottleLib.Hook_SendAddonMessage(prefix, text, "WHISPER", destination)
 end
 
 
@@ -630,6 +641,34 @@ function ChatThrottleLib:SendAddonMessageLogged(prio, prefix, text, chattype, ta
 
 	local sendFunction = _G.C_ChatInfo.SendAddonMessageLogged
 	SendAddonMessageInternal(self, sendFunction, prio, prefix, text, chattype, target, queueName, callbackFn, callbackArg)
+end
+
+local function BNSendGameDataReordered(prefix, text, _, gameAccountID)
+	return _G.BNSendGameData(gameAccountID, prefix, text)
+end
+
+function ChatThrottleLib:BNSendGameData(prio, prefix, text, chattype, gameAccountID, queueName, callbackFn, callbackArg)
+	-- Note that this API is intentionally limited to 255 bytes of data
+	-- for reasons of traffic fairness, which is less than the 4078 bytes
+	-- BNSendGameData natively supports. Additionally, a chat type is required
+	-- but must always be set to 'WHISPER' to match what is exposed by the
+	-- receipt event.
+	--
+	-- If splitting messages, callers must also be aware that message
+	-- delivery over BNSendGameData is unordered.
+
+	if not self or not prio or not prefix or not text or not gameAccountID or not chattype or not self.Prio[prio] then
+		error('Usage: ChatThrottleLib:BNSendGameData("{BULK||NORMAL||ALERT}", "prefix", "text", "chattype", gameAccountID)', 2)
+	elseif callbackFn and type(callbackFn)~="function" then
+		error('ChatThrottleLib:BNSendGameData(): callbackFn: expected function, got '..type(callbackFn), 2)
+	elseif #text>255 then
+		error("ChatThrottleLib:BNSendGameData(): message length cannot exceed 255 bytes", 2)
+	elseif chattype ~= "WHISPER" then
+		error("ChatThrottleLib:BNSendGameData(): chat type must be 'WHISPER'", 2)
+	end
+
+	local sendFunction = BNSendGameDataReordered
+	SendAddonMessageInternal(self, sendFunction, prio, prefix, text, chattype, gameAccountID, queueName, callbackFn, callbackArg)
 end
 
 


### PR DESCRIPTION
This adds the necessary hooks and public APIs to support sending comms over the BNSendGameData API.

There's a few differences to note up-front about CTL's provided interface for this functionality.

- The BNSendGameData API supports sending messages up to 4078 bytes in length, but our implementation limits it to 255 bytes.
- The BNSendGameData API has a different parameter ordering and no 'chattype' parameter, whereas our implementation has a parameter ordering consistent with SendAddonMessage and requires a chattype.

On message size, our round-robin message selection effectively pauses when it reaches a message for which there isn't yet enough accrued bandwidth to send. In the case of 4078 byte messages that this API supports, this could mean with the current CPS value that a priority blocks for up to 5 seconds before enough bandwidth is available to send it off. This would be extremely unfair to everything else sending data, so limiting it to the usual 255 bytes sounds more reasonable.

On parameter ordering, there's an inconsistency between the API's parameters and the data supplied in its event; the API doesn't have a chattype parameter but its receipt event fires with one always set to 'WHISPER'.

If the API changed to require a chattype parameter down the line it would require a backwards compatibility break in our interface if we hadn't accommodated it, so it feels sensible to just require it up-front even if it must always be 'WHISPER'.

With both the message size and added chattype parameter in mind, it then also makes sense to just make the interface have the same parameter ordering as SendAddonMessage to make it a bit easier to generically use these functions. BNSendGameData requires an order of `(target, prefix, data)`, whereas our interface is the standard `(prio, prefix, data, chattype, target, ...)`.

