### PR TITLE
Move Link method off Ring metatable

### DIFF
--- a/AceComm-3.0/ChatThrottleLib.lua
+++ b/AceComm-3.0/ChatThrottleLib.lua
@@ -23,7 +23,7 @@
 -- LICENSE: ChatThrottleLib is released into the Public Domain
 --
 
-local CTL_VERSION = 26
+local CTL_VERSION = 27
 
 local _G = _G
 
@@ -115,7 +115,10 @@ function Ring:Remove(obj)
 	end
 end
 
-function Ring:Link(other)  -- Move and append all contents of another ring to this ring
+-- Note that this is local because there's no upgrade logic for existing ring
+-- metatables, and this isn't present on rings created in versions older than
+-- v25.
+local function Ring_Link(self, other)  -- Move and append all contents of another ring to this ring
 	if not self.pos then
 		-- This ring is empty, so just transfer ownership.
 		self.pos = other.pos
@@ -425,7 +428,7 @@ function ChatThrottleLib.OnUpdate(this,delay)
 	-- Integrate blocked queues back into their rings periodically.
 	if self.BlockedQueuesDelay >= 0.35 then
 		for _, Prio in pairs(self.Prio) do
-			Prio.Ring:Link(Prio.Blocked)
+			Ring_Link(Prio.Ring, Prio.Blocked)
 		end
 
 		self.BlockedQueuesDelay = 0


### PR DESCRIPTION
There's a bug in the upgrade logic where existing rings created by older versions of the library never have their metatables upgraded. As such, a load of a version older than v25 followed by v25 or newer will result in a call to a nil 'Link' method on rings.

![image](https://github.com/WoWUIDev/Ace3/assets/287102/4e2c37f1-3bb0-4894-b001-a39faf0e0e7a)

Rather than think through the ramifications of just setmetatable-ing rings again unilaterally on upgrade (though that is probably a perfectly sane idea and should work), for now let's just make the new Link method a local function instead as that's the safer option.