### PR TITLE
Add gamepad support to keybinding widget

### DIFF
--- a/AceGUI-3.0/widgets/AceGUIWidget-Keybinding.lua
+++ b/AceGUI-3.0/widgets/AceGUIWidget-Keybinding.lua
@@ -2,7 +2,7 @@
 Keybinding Widget
 Set Keybindings in the Config UI.
 -------------------------------------------------------------------------------]]
-local Type, Version = "Keybinding", 26
+local Type, Version = "Keybinding", 27
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
@@ -31,12 +31,14 @@ local function Keybinding_OnClick(frame, button)
 		if self.waitingForKey then
 			frame:EnableKeyboard(false)
 			frame:EnableMouseWheel(false)
+			frame:EnableGamePadButton(false)
 			self.msgframe:Hide()
 			frame:UnlockHighlight()
 			self.waitingForKey = nil
 		else
 			frame:EnableKeyboard(true)
 			frame:EnableMouseWheel(true)
+			frame:EnableGamePadButton(true)
 			self.msgframe:Show()
 			frame:LockHighlight()
 			self.waitingForKey = true
@@ -72,6 +74,7 @@ local function Keybinding_OnKeyDown(frame, key)
 
 		frame:EnableKeyboard(false)
 		frame:EnableMouseWheel(false)
+		frame:EnableGamePadButton(false)
 		self.msgframe:Hide()
 		frame:UnlockHighlight()
 		self.waitingForKey = nil
@@ -119,6 +122,7 @@ local methods = {
 		self:SetDisabled(false)
 		self.button:EnableKeyboard(false)
 		self.button:EnableMouseWheel(false)
+		self.button:EnableGamePadButton(false)
 	end,
 
 	-- ["OnRelease"] = nil,
@@ -195,10 +199,12 @@ local function Constructor()
 	button:SetScript("OnKeyDown", Keybinding_OnKeyDown)
 	button:SetScript("OnMouseDown", Keybinding_OnMouseDown)
 	button:SetScript("OnMouseWheel", Keybinding_OnMouseWheel)
+	button:SetScript("OnGamePadButtonDown", Keybinding_OnKeyDown)
 	button:SetPoint("BOTTOMLEFT")
 	button:SetPoint("BOTTOMRIGHT")
 	button:SetHeight(24)
 	button:EnableKeyboard(false)
+	button:EnableGamePadButton(false)
 
 	local text = button:GetFontString()
 	text:SetPoint("LEFT", 7, 0)


### PR DESCRIPTION
Gamepad bindings are completely in line with the rest of the keybinding system in WoW, so all that's really necessary to make them work in AceGUI is to add a handler to catch bindings.