### PR TITLE
Fix AceComm for communicating cross realm

### DIFF
--- a/AceComm-3.0/AceComm-3.0.lua
+++ b/AceComm-3.0/AceComm-3.0.lua
@@ -119,14 +119,24 @@ function AceComm:SendCommMessage(prefix, text, distribution, target, prio, callb
 		-- fits all in one message
 		CTL:SendAddonMessage(prio, prefix, text, distribution, target, queueName, ctlCallback, textlen)
 	else
-		local chunkCount = tostring(ceil(#text / maxtextlen))
-		-- We send the part number and chunk count as strings, so reserve place for that
-		maxtextlen = maxtextlen - 3 - 2 * #chunkCount
+		local chunkCount = math.ceil(#text / maxtextlen)
+		local chunklen
+		while(true) do
+			-- We send the part number and chunk count as strings, so reserve place for that
+			chunklen = maxtextlen - 3 - 2 * #tostring(chunkCount)
+			local newChunkCount = math.ceil(#text / chunklen)
+			if newChunkCount == chunkCount then
+				break
+			end
+			chunkCount = newChunkCount
+		end
+
+		print("chunkCount", chunkCount, "chunklen", chunklen)
 
 		for i = 1, chunkCount do
-			local header = MSG_MULTI_HEADER .. tostring(i) .. MSG_MULTI_HEADER_SEP .. chunkCount .. MSG_MULTI_HEADER_END
-			local chunkStart = (i - 1) * maxtextlen + 1
-			local chunkEnd = chunkStart + maxtextlen - 1
+			local header = MSG_MULTI_HEADER .. tostring(i) .. MSG_MULTI_HEADER_SEP .. tostring(chunkCount) .. MSG_MULTI_HEADER_END
+			local chunkStart = (i - 1) * chunklen + 1
+			local chunkEnd = chunkStart + chunklen - 1
 			print("Sending: ", i, chunkCount)
 			CTL:SendAddonMessage(prio, prefix, header .. text:sub(chunkStart, chunkEnd), distribution, target, queueName, ctlCallback, chunkEnd)
 		end

--- a/AceComm-3.0/AceComm-3.0.lua
+++ b/AceComm-3.0/AceComm-3.0.lua
@@ -53,7 +53,7 @@ AceComm.multipart_reassemblers = nil
 -- the multipart message spool: indexed by a combination of sender+distribution+
 AceComm.multipart_spool = AceComm.multipart_spool or {}
 -- Sequence is an integer between 0 and 254 * 254
-AceComm.sequence = random(254 * 254)
+AceComm.sequence = math.random(254 * 254)
 
 --- Register for Addon Traffic on a specified prefix
 -- @param prefix A printable character (\032-\255) classification of the message (typically AddonName or AddonNameEvent), max 16 characters
@@ -136,7 +136,7 @@ function AceComm:SendCommMessage(prefix, text, distribution, target, prio, callb
 		print("chunkCount", chunkCount, "chunklen", chunklen)
 
 		-- Convert sequence number to 2 bytes, while avoiding \0 bytes
-		local sequence = string.char(AceComm.sequence % 254 + 1) .. string.char(floor(AceComm.sequence / 254) + 1)
+		local sequence = string.char(AceComm.sequence % 254 + 1) .. string.char(math.floor(AceComm.sequence / 254) + 1)
 		AceComm.sequence = (AceComm.sequence + 1) % (254 * 254)
 
 		for i = 1, chunkCount do


### PR DESCRIPTION
When sending mulitpart messsages across realms, the messages can be received out of order. Fix this by introducing a new header that contains the message number and message total.