### PR TITLE
New Library: AceState! A state lifecycle management library implementing the action/reducer pattern to update immutable state. Works well in tandem with AceDB.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ AceHook-3.0/*.toc
 AceLocale-3.0/*.toc
 AceLocale-3.0/luac.out
 AceSerializer-3.0/*.toc
+AceState-3.0/*.toc
 AceTimer-3.0/*.toc
 CallbackHandler-1.0/*.toc

--- a/Ace3.toc
+++ b/Ace3.toc
@@ -24,5 +24,6 @@ AceConfig-3.0\AceConfig-3.0.xml
 AceComm-3.0\AceComm-3.0.xml
 AceTab-3.0\AceTab-3.0.xml
 AceSerializer-3.0\AceSerializer-3.0.xml
+AceState-3.0\AceState-3.0.xml
 
 Ace3.lua

--- a/AceState-3.0/AceState-3.0.lua
+++ b/AceState-3.0/AceState-3.0.lua
@@ -1,0 +1,110 @@
+local MAJOR, MINOR = "AceState-3.0", 1
+local AceState, oldminor = LibStub:NewLibrary(MAJOR, MINOR)
+
+if not AceState then
+	return -- No upgrade needed
+end
+
+-- Register a reducer with the initial state and the reducer function
+function AceState:RegisterReducer(name, initialState, reducer)
+	-- If the reducer is a string, it should be a method on the addon
+	if type(reducer) == "string" then
+		if not self[reducer] or type(self[reducer]) ~= "function" then
+			error("Reducer method " .. reducer .. " does not exist on addon")
+		end
+		reducer = self[reducer]
+	elseif type(reducer) ~= "function" then
+		error("Reducer must be a function or a string referring to a method on the addon.")
+	end
+
+	-- Return a dispatch function for this reducer
+	local dispatch = function(actionType, payload)
+		local oldState = self.DeepCopy(self.state[name])
+		local newState = self.reducers[name](oldState, actionType, payload)
+
+		-- Update the state
+		for k, v in pairs(newState) do
+			self.state[name][k] = v
+		end
+		for k in pairs(self.state[name]) do
+			if newState[k] == nil then
+				self.state[name][k] = nil
+			end
+		end
+	end
+
+	-- Store the initial state and the reducer
+	self.state = self.state or {}
+	self.state[name] = initialState
+	self.reducers = self.reducers or {}
+	self.reducers[name] = reducer
+	self.dispatchers = self.dispatchers or {}
+	self.dispatchers[name] = dispatch
+
+	return dispatch
+end
+
+-- Dispatch an action to all reducers
+function AceState:Dispatch(actionType, payload)
+	if not self.reducers then
+		error("No reducers registered")
+	end
+
+	for _, dispatch in pairs(self.dispatchers) do
+		dispatch(actionType, payload)
+	end
+end
+
+-- Get the current state
+function AceState:GetState(name)
+	if name then
+		return self.state and self.state[name]
+	else
+		return self.state
+	end
+end
+
+-- Utility function for creating deep copies of objects.
+function AceState:DeepCopy(orig, seen)
+	if type(orig) ~= "table" then
+		return orig
+	end
+	if seen and seen[orig] then
+		return seen[orig]
+	end
+	local s = seen or {}
+	local res = setmetatable({}, getmetatable(orig))
+	s[orig] = res
+	for k, v in pairs(orig) do
+		res[self.DeepCopy(k, s)] = self.DeepCopy(v, s)
+	end
+	return res
+end
+
+-- Embedding
+AceState.embeds = AceState.embeds or {}
+
+local mixins = {
+	"RegisterReducer",
+	"Dispatch",
+	"GetState",
+}
+
+-- Embed AceState into another addon
+function AceState:Embed(target)
+	for _, v in ipairs(mixins) do
+		target[v] = self[v]
+	end
+	self.embeds[target] = true
+	return target
+end
+
+-- Handle disabling of an addon
+function AceState:OnEmbedDisable(target)
+	self[target] = nil
+end
+
+-- Re-embed in case of upgrades
+for addon in pairs(AceState.embeds) do
+	AceState:Embed(addon)
+end

--- a/AceState-3.0/AceState-3.0.xml
+++ b/AceState-3.0/AceState-3.0.xml
@@ -1,0 +1,4 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+..\FrameXML\UI.xsd">
+	<Script file="AceState-3.0.lua"/>
+</Ui>

--- a/tests/AceState-3.0.lua
+++ b/tests/AceState-3.0.lua
@@ -1,0 +1,57 @@
+dofile("wow_api.lua")
+dofile("LibStub.lua")
+dofile("../AceState-3.0/AceState-3.0.lua")
+
+-- Test RegisterReducer
+do
+	local AceState = LibStub("AceState-3.0")
+	local initialState = { count = 0 }
+	local reducer = function(state, actionType, payload)
+		if actionType == "INCREMENT" then
+			return { count = state.count + 1 }
+		else
+			return state
+		end
+	end
+	local dispatch = AceState:RegisterReducer("count", initialState, reducer)
+	-- Dispatching no actions should leave count at zero.
+	assert(AceState:GetState("count").count == 0)
+end
+
+-- Test Dispatch
+do
+	local AceState = LibStub("AceState-3.0")
+	local initialState = { count = 0 }
+	local reducer = function(state, actionType, payload)
+		if actionType == "INCREMENT" then
+			if not payload then
+				payload = 1
+			end
+			return { count = state.count + payload }
+		else
+			return state
+		end
+	end
+	local dispatch = AceState:RegisterReducer("count", initialState, reducer)
+	dispatch("INCREMENT")
+	assert(AceState:GetState("count").count == 1)
+	dispatch("INCREMENT", 5)
+	assert(AceState:GetState("count").count == 6)
+end
+
+-- Test Embed
+do
+	local MyAddon = {}
+	local AceState = LibStub("AceState-3.0"):Embed(MyAddon)
+	local initialState = { count = 0 }
+	local reducer = function(state, actionType, payload)
+		if actionType == "INCREMENT" then
+			return { count = state.count + 1 }
+		else
+			return state
+		end
+	end
+	local dispatch = MyAddon:RegisterReducer("count", initialState, reducer)
+	dispatch("INCREMENT")
+	assert(MyAddon:GetState("count").count == 1)
+end


### PR DESCRIPTION
As a web developer I've gotten used to so many quality of life tools and libraries. When I invariably come back to dabble in WoW addons with Lua I quickly remember how much low level work will be involved once an addon starts to become reasonably complex. One of these annoyances is keeping state manageable. Most recently I had to synchronize data between multiple clients to keep quest data updated amongst all players in the same party for my [QuestTogether](https://www.curseforge.com/wow/addons/questtogether) addon. This took an already working addon and immediately ballooned the complexity by a couple orders of magnitude.

I now had many functions trying to modify the same state. The addon has to work while solo too so I can't rely on party comm messages for local operations. For example, I'd have to update a giant `questTracker` object with the player's current quests and objectives, but now that I want each client to keep track of each player's quests in a party I had to expand the object to contain multiple quest trackers by character name and I had to create broadcasts that would send out quest updates from each client to all other clients so they too could update their copy of each player's quests.

Basically I had to run similar logic in comm received functions and various WoW event handler functions. It was becoming quite unweildy to keep track of it all. I needed a proper state machine. That's when it hit me that it's time for me to build a library and implement the action/reducer pattern. But then I quickly realized that this functionality would fit perfectly into the Ace3 suite! So rather than publish my own standalone addon I figured I'd take a stab at adding it here. If for some reason this is not desired then I'll go ahead and publish a standalone library, but hopefully you feel similarly that this is a elegant and lightweight solution that adds a cool way to reduce addon state management complexity without adding unnecessary bloat to Ace3 itself

Without further ado, here is a basic usage example showing how one would use AceState:

```lua
StepCounterAddon = LibStub("AceAddon-3.0"):NewAddon(
    "QuestTogether",
    "AceConsole-3.0",
    "AceEvent-3.0",
    "AceState-3.0",
    "AceTimer-3.0"
)

StepCounterAddon.defaultOptions = {
    char = {
        steps = 0,
    },
}

function StepCounterAddon:OnInitialize()
    self.db = LibStub("AceDB-3.0"):New("StepCounterDB", self.defaultOptions, true)

    -- Here we register our reducers with AceState.
    -- Once registered we can dispatch actions to them via self:Dispatch.
    self:RegisterReducer("addon", self.db.global, "AddonReducer")
    -- We can also get reference to a reducer-specific dispatch function
    -- by storing the function returned from RegisterReducer.
    local stepsDispatch = self:RegisterReducer("steps", self.db.char, "StepsReducer")

    -- Example action dispatching.
    -- stepsDispatch("SET_STEPS", { steps = 5 })

    -- Typically it is simplest to just use the global dispatch method.
    -- self:Dispatch("SET_STEPS", { steps = 5 })
    -- self:Dispatch can dispatch any action from any registerd reducers.
    -- If two reducers define the same action then both actions would be
    -- dispatched when using self:Dispatch.

    self:Print("Step Counter Addon initialized.")
end

function StepCounterAddon:OnEnable()
    self:RegisterEvent("PLAYER_STARTED_MOVING")
    self:RegisterEvent("PLAYER_STOPPED_MOVING")

    self:Print("Step Counter Addon enabled.")
end

function StepCounterAddon:OnDisable()
    self:Print("Step Counter Addon disabled.")
end

function StepCounterAddon:AddonReducer(state, action, payload)
    if action == "ENABLE_ADDON" then
        self:Enable()
    elseif action == "DISABLE_ADDON" then
        self:Disable()
    else
        error("Unknown action type: " .. action)
    end
    -- This reducer didn't actually modify state, so we just return the original state.
    return state
end

function StepCounterAddon:StepsReducer(state, action, payload)
    -- state is a deep copy of self.db.char and can be modified directly
    -- ensuring original state is immutable (not modified)
    if action == "INCREMENT_STEPS" then
        if not payload.increment then
            error("INCREMENT_STEPS Error: No increment value provided.")
        end
        -- Only by returning a new state object will AceState update the
        -- original state object at self.db.char
        return {
            steps = state.steps + payload.increment,
        }
    elseif action == "RESET_STEPS" then
        return {
            steps = 0,
        }
        elseif action == "SET_STEPS" then
        if not payload.steps then
            error("SET_STEPS Error: No steps value provided.")
        end
        return {
            steps = payload.steps,
        }
    else -- unknown action
        error("Unknown action type: " .. action)
    end
    -- NOTE: Whatever is returned from the reducer replaces state entirely.
    -- In this case, self.db.char is the original state object reference
    -- so it will be replaced with the new state object.
    -- This is done by transplanting the new state object's key-value pairs
    -- onto the original state object. This ensures that any references
    -- to the original state object remain valid.
end

function StepCounterAddon:PLAYER_STARTED_MOVING()
    self.timerId = self:ScheduleRepeatingTimer(function()
        -- We can trigger any action in any reducer by using the embedded Dispatch method.
        self:Dispatch("INCREMENT_STEPS", { increment = 1 })
    end, 1)
end

function StepCounterAddon:PLAYER_STOPPED_MOVING()
    self:CancelTimer(self.timerId)
end
```