### PR TITLE
Prevent TreeGroup buttons being broken somehow

### DIFF
--- a/AceGUI-3.0/widgets/AceGUIContainer-TreeGroup.lua
+++ b/AceGUI-3.0/widgets/AceGUIContainer-TreeGroup.lua
@@ -2,7 +2,7 @@
 TreeGroup Container
 Container that uses a tree control to switch between groups.
 -------------------------------------------------------------------------------]]
-local Type, Version = "TreeGroup", 47
+local Type, Version = "TreeGroup", 48
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
@@ -387,10 +387,6 @@ local methods = {
 	["RefreshTree"] = function(self,scrollToSelection,fromOnUpdate)
 		local buttons = self.buttons
 		local lines = self.lines
-
-		for i, v in ipairs(buttons) do
-			v:Hide()
-		end
 		while lines[1] do
 			local t = tremove(lines)
 			for k in pairs(t) do
@@ -469,6 +465,9 @@ local methods = {
 			end
 		end
 
+		for i, v in ipairs(buttons) do
+			v.shouldBeHidden = true
+		end
 		local buttonnum = 1
 		for i = first, last do
 			local line = lines[i]
@@ -496,9 +495,14 @@ local methods = {
 
 			UpdateButton(button, line, status.selected == line.uniquevalue, line.hasChildren, groupstatus[line.uniquevalue] )
 			button:Show()
+			button.shouldBeHidden = nil
 			buttonnum = buttonnum + 1
 		end
-
+		for i, v in ipairs(buttons) do
+			if v.shouldBeHidden then
+				v:Hide()
+			end
+		end
 	end,
 
 	["SetSelected"] = function(self, value)

--- a/AceGUI-3.0/widgets/AceGUIContainer-TreeGroup.lua
+++ b/AceGUI-3.0/widgets/AceGUIContainer-TreeGroup.lua
@@ -465,6 +465,7 @@ local methods = {
 			end
 		end
 
+		-- We hide the buttons after updating them to avoid a blizzard bug that causes the buttons to still be interactable even when hidden.
 		for i, v in ipairs(buttons) do
 			v.shouldBeHidden = true
 		end

--- a/AceGUI-3.0/widgets/AceGUIContainer-TreeGroup.lua
+++ b/AceGUI-3.0/widgets/AceGUIContainer-TreeGroup.lua
@@ -495,8 +495,7 @@ local methods = {
 			buttonnum = buttonnum + 1
 		end
 
-		-- We hide the remaining buttons after updating others to avoid a blizzard bug,
-		-- this used to be done for all buttons at the top of this function
+		-- We hide the remaining buttons after updating others to avoid a blizzard bug that keeps them interactable even if hidden when hidden before updating the buttons.
 		for i = buttonnum, #buttons do
 			buttons[i]:Hide()
 		end

--- a/AceGUI-3.0/widgets/AceGUIContainer-TreeGroup.lua
+++ b/AceGUI-3.0/widgets/AceGUIContainer-TreeGroup.lua
@@ -465,10 +465,6 @@ local methods = {
 			end
 		end
 
-		-- We hide the buttons after updating them to avoid a blizzard bug that causes the buttons to still be interactable even when hidden.
-		for i, v in ipairs(buttons) do
-			v.shouldBeHidden = true
-		end
 		local buttonnum = 1
 		for i = first, last do
 			local line = lines[i]
@@ -496,13 +492,13 @@ local methods = {
 
 			UpdateButton(button, line, status.selected == line.uniquevalue, line.hasChildren, groupstatus[line.uniquevalue] )
 			button:Show()
-			button.shouldBeHidden = nil
 			buttonnum = buttonnum + 1
 		end
-		for i, v in ipairs(buttons) do
-			if v.shouldBeHidden then
-				v:Hide()
-			end
+
+		-- We hide the remaining buttons after updating others to avoid a blizzard bug,
+		-- this used to be done for all buttons at the top of this function
+		for i = buttonnum, #buttons do
+			buttons[i]:Hide()
 		end
 	end,
 


### PR DESCRIPTION
There has been the issue of BW treegroup being shown after closing the menu, which is also visible in different ways - even though the frames are hidden correctly and are not shown in /fstack.

![image](https://github.com/user-attachments/assets/a5f2c6cb-b5bd-4446-8020-281419fc92e0)

After just trying some things, I noticed that hiding the frames at the end of the logic resulted in more robust handling of the situation. That's why the code is as it is now.

I have also tried just hiding the frames in the for loop on line 468-470, that however resulted in the same issue. 

Here are 2 clips with the change, and without the change:

Hiding before re-creating the tree:
https://streamable.com/grj7oe

Hiding after creating the tree:
https://streamable.com/3t4qpg

I've used this for some weeks, and not had issues after adding this and I don't see why we wouldn't add this atm.
