### PR TITLE
Enable "relative" width support

### DIFF
--- a/AceConfig-3.0/AceConfigDialog-3.0/AceConfigDialog-3.0.lua
+++ b/AceConfig-3.0/AceConfigDialog-3.0/AceConfigDialog-3.0.lua
@@ -1436,12 +1436,15 @@ local function FeedOptions(appName, options,container,rootframe,path,group,inlin
 				if control then
 					if control.width ~= "fill" then
 						local width = GetOptionsMemberValue("width",v,options,path,appName)
+						local relWidth = GetOptionsMemberValue("relWidth",v,options,path,appName)
 						if width == "double" then
 							control:SetWidth(width_multiplier * 2)
 						elseif width == "half" then
 							control:SetWidth(width_multiplier / 2)
 						elseif (type(width) == "number") then
 							control:SetWidth(width_multiplier * width)
+						elseif width == "relative" and relWidth then
+							control:SetRelativeWidth(relWidth)
 						elseif width == "full" then
 							control.width = "fill"
 						else

--- a/AceConfig-3.0/AceConfigRegistry-3.0/AceConfigRegistry-3.0.lua
+++ b/AceConfig-3.0/AceConfigRegistry-3.0/AceConfigRegistry-3.0.lua
@@ -92,6 +92,7 @@ local basekeys={
 	func=optmethodfalse,
 	arg={["*"]=true},
 	width=optstringnumber,
+	relWidth=optnumber,
 }
 
 local typedkeys={

--- a/AceGUI-3.0/AceGUI-3.0.lua
+++ b/AceGUI-3.0/AceGUI-3.0.lua
@@ -772,7 +772,7 @@ AceGUI:RegisterLayout("Flow",
 				rowoffset = child.alignoffset or (rowheight / 2)
 				rowstartoffset = rowoffset
 			elseif child.width == "relative" then
-				safelayoutcall(child, "SetWidth", width * child.relWidth)
+				safelayoutcall(child, "SetWidth", framewidth)
 
 				if child.DoLayout then
 					child:DoLayout()


### PR DESCRIPTION
As the title suggests, it's enables the "relative" width support. It's already fully implemented in AceGUI, but AceConfig had no access to it.

I added `relWidth` to `basekeys`, but I'm not entirely sure about this one, we might want to be a bit more intentional with which controls support it, but idk.

```lua
width =  "relative",
relWidth = 0.25,
```
Will result in a widget that takes up a quarter of the container's width.

https://github.com/user-attachments/assets/2097e84b-be2d-448c-822f-deddfa7f4399

It's really handy for making equally spaced buttons.